### PR TITLE
Publicera förmedlare uppdrag och slutkundsuppdrag i separata kanaler

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
       'never',
     ],
     'indent': ['error', 2],
+    'no-tabs': 1,
   },
   'parserOptions': {
     'ecmaVersion': 2021,

--- a/backend/config.js.example
+++ b/backend/config.js.example
@@ -49,7 +49,10 @@ module.exports = {
     `,
   },
   slack: {
-    channel: '#...',
+    channels: {
+      'BROKER': '#...',
+      'DIRECT': '#...',
+    },
     token: '',
   },
 }

--- a/backend/src/common.js
+++ b/backend/src/common.js
@@ -36,7 +36,7 @@ exports.validateEmail = emailAddress => {
 
 exports.fillTemplate = (template, source) => {
   let body = template
-	
+
   // ta bort mellanslag och tabbar pga. indentering
   body = body.trim().replace(/\n[ \t]+/g, '\n')
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ const mysql = require('mysql2/promise')
 const bodyParser = require('body-parser')
 
 const model = require('./model')
+const slack = require('./slack')
 const config = require('../config')
 
 const app = express()
@@ -33,5 +34,7 @@ app.use(bodyParser.urlencoded({ extended : true }))
 app.use('/api/assignments', require('./rest/assignments'))
 
 model.setPool(pool)
+
+slack.sync()
 
 httpServer.listen(config.listen.port, config.listen.ip)

--- a/backend/src/model.js
+++ b/backend/src/model.js
@@ -18,20 +18,20 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
 
   await this.pool.query(
     `
-		INSERT INTO assignment (
-			id,
+    INSERT INTO assignment (
+      id,
       senderType,
-			emailAddress,
-			customerName,
-			title,
-			description,
-			contact,
-			created,
+      emailAddress,
+      customerName,
+      title,
+      description,
+      contact,
+      created,
       slackChannel,
-			slackId
-		)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, [
+      slackId
+    )
+    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `, [
       id,
       senderType,
       emailAddress,
@@ -53,20 +53,20 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
 exports.getAssignment = async assignmentId => {
   const [assignments] = await this.pool.query(
     `
-		SELECT
-			id,
+    SELECT
+      id,
       senderType,
-			emailAddress,
-			customerName,
-			title,
-			description,
-			contact,
-			created,
+      emailAddress,
+      customerName,
+      title,
+      description,
+      contact,
+      created,
       slackChannel,
-			slackId
-		FROM assignment
-		WHERE id = ?
-		`,
+      slackId
+    FROM assignment
+    WHERE id = ?
+    `,
     [assignmentId],
   )
 
@@ -92,10 +92,10 @@ exports.getAssignmentThatNeedSlackPropagation = async () => {
 exports.assignmentExists = async assignmentId => {
   const count = (await this.pool.query(
     `
-		SELECT COUNT(*) AS count
-		FROM assignment
-		WHERE id = ?
-		`,
+    SELECT COUNT(*) AS count
+    FROM assignment
+    WHERE id = ?
+    `,
     [assignmentId],
   ))[0][0].count
 
@@ -105,14 +105,14 @@ exports.assignmentExists = async assignmentId => {
 exports.getAssignmentComments = async assignmentId => {
   const [comments] = await this.pool.query(
     `
-		SELECT
-			id,
-			comment,
-			created,
-			slackId
-		FROM assignmentComment
-		WHERE assignment = ?
-		`,
+    SELECT
+      id,
+      comment,
+      created,
+      slackId
+    FROM assignmentComment
+    WHERE assignment = ?
+    `,
     [assignmentId],
   )
 
@@ -125,19 +125,19 @@ exports.saveAssignmentComment = async (assignmentId, comment) => {
 
   await this.pool.query(
     `
-		INSERT INTO assignmentComment (
-			assignment,
-			id,
-			comment,
-			created,
-			slackId
-		)
-		VALUES(?, (
-			SELECT COUNT(*) + 1
-			FROM assignmentComment AS t
-			WHERE t.assignment = ?
-		), ?, ?, ?)
-		`, [
+    INSERT INTO assignmentComment (
+      assignment,
+      id,
+      comment,
+      created,
+      slackId
+    )
+    VALUES(?, (
+      SELECT COUNT(*) + 1
+      FROM assignmentComment AS t
+      WHERE t.assignment = ?
+    ), ?, ?, ?)
+    `, [
       assignmentId,
       assignmentId,
       comment,
@@ -151,10 +151,10 @@ exports.saveAssignmentComment = async (assignmentId, comment) => {
 
 exports.setAssignmentSlackId = async (assignmentId, slackId) => await this.pool.query(
   `
-	UPDATE assignment
-	SET slackId = ?
-	WHERE id = ?
-	`, [
+  UPDATE assignment
+  SET slackId = ?
+  WHERE id = ?
+  `, [
     slackId,
     assignmentId,
   ],
@@ -162,10 +162,10 @@ exports.setAssignmentSlackId = async (assignmentId, slackId) => await this.pool.
 
 exports.setAssignmentCommentSlackId = async (assignmentId, id, slackId) => await this.pool.query(
   `
-	UPDATE assignmentComment
-	SET slackId = ?
-	WHERE assignment = ? AND id = ?
-	`, [
+  UPDATE assignmentComment
+  SET slackId = ?
+  WHERE assignment = ? AND id = ?
+  `, [
     slackId,
     assignmentId,
     id,

--- a/backend/src/rest/assignments.js
+++ b/backend/src/rest/assignments.js
@@ -8,6 +8,7 @@ const model = require('../model')
 const router = express.Router()
 
 router.post('/', async (req, res) => {
+  let senderType = req.body.senderType
   let emailAddress = req.body.emailAddress
   let customerName = req.body.customerName
   let title = req.body.title
@@ -26,12 +27,13 @@ router.post('/', async (req, res) => {
     return
   }
 
-  if (emailAddress.length > 50 || title.length > 50 || title.length > 50) {
+  if (emailAddress.length > 50 || title.length > 50 || title.length > 50 || !['BROKER', 'DIRECT'].includes(senderType)) {
     res.status(400).end()
     return
   }
 
   const assignmentId = await model.saveAssignment(
+    senderType,
     emailAddress,
     customerName,
     title,
@@ -54,6 +56,7 @@ router.get('/:assignmentId', async (req, res) => {
 
   res.json({
     id: assignment.id,
+    senderType: assignment.senderType,
     customerName: assignment.customerName,
     title: assignment.title,
     description: assignment.description,

--- a/backend/src/slack.js
+++ b/backend/src/slack.js
@@ -18,11 +18,11 @@ exports.propagateAssignment = async assignmentId => {
   const text = common.fillTemplate(config.templates.slackAssignment, assignment)
 
   const params = new URLSearchParams()
-	
+
   params.append('token', config.slack.token)
   params.append('channel', assignment.slackChannel)
   params.append('text', text)
-	
+
   let ok, ts
 
   try {

--- a/backend/src/slack.js
+++ b/backend/src/slack.js
@@ -4,6 +4,14 @@ const common = require('./common')
 const model = require('./model')
 const config = require('../config')
 
+exports.sync = async () => {
+  const ids = await model.getAssignmentThatNeedSlackPropagation()
+
+  for (const id of ids) {
+    await this.propagateAssignment(id)
+  }
+}
+
 exports.propagateAssignment = async assignmentId => {
   const assignment = await model.getAssignment(assignmentId)
 
@@ -12,7 +20,7 @@ exports.propagateAssignment = async assignmentId => {
   const params = new URLSearchParams()
 	
   params.append('token', config.slack.token)
-  params.append('channel', config.slack.channel)
+  params.append('channel', assignment.slackChannel)
   params.append('text', text)
 	
   let ok, ts
@@ -24,6 +32,8 @@ exports.propagateAssignment = async assignmentId => {
 
     if (ok) {
       ts = response.data.ts
+    } else {
+      throw response.data
     }
   } catch (error) {
     console.error('Failed to post assignment ' + assignmentId + ' to Slack:')
@@ -54,7 +64,7 @@ exports.propagateAssignmentComments = async assignmentId => {
     const params = new URLSearchParams()
     
     params.append('token', config.slack.token)
-    params.append('channel', config.slack.channel)
+    params.append('channel', assignment.slackChannel)
     params.append('thread_ts', assignment.slackId)
     params.append('reply_broadcast', 'true')
     params.append('text', text)
@@ -68,6 +78,8 @@ exports.propagateAssignmentComments = async assignmentId => {
 
       if (ok) {
         ts = response.data.ts
+      } else {
+        throw response.data
       }
     } catch (error) {
       console.error('Failed to post assignment comment (' + assignmentId + ', ' + comment.id + ') to Slack:')

--- a/backend/structure.sql
+++ b/backend/structure.sql
@@ -3,12 +3,14 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `assignment` (
   `id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  `senderType` enum('DIRECT','BROKER') COLLATE utf8mb4_unicode_ci NOT NULL,
   `emailAddress` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `customerName` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `description` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `contact` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `created` bigint(30) NOT NULL,
+  `slackChannel` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `slackId` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -86,6 +86,19 @@ input[type='submit']:active {
   background-color: #cccccc;
 }
 
+label > input[type='radio'] {
+  display: inline;
+  width: auto;
+}
+
+label.radio {
+  display: block;
+}
+
+label:not(.radio) + label.radio {
+  margin-top: 15px;
+}
+
 input:active, textarea:active, input:focus-visible, textarea:focus-visible {
   outline: none;
   border: 1px solid #444444;

--- a/frontend/src/components/Assignment.vue
+++ b/frontend/src/components/Assignment.vue
@@ -7,7 +7,7 @@
     <p>{{ assignment.customerName }}</p>
 
     <h4>Kontaktuppgifter</h4>
-    <p>{{ assignment.contact }}</p>
+    <p>{{ assignment.contact }} ({{ niceSenderType(assignment.senderType) }})</p>
 
     <template v-if="assignment.comments">
       <template :key="comment.id" v-for="comment in assignment.comments">
@@ -28,7 +28,16 @@ export default {
   methods: {
     niceTimestamp(timestamp) {
       return format(timestamp * 1000, "'den' PPP 'klockan' p", { locale: sv })
-    }
+    },
+
+    niceSenderType(senderType) {
+      switch (senderType) {
+        case 'BROKER': return 'förmedlare'
+        case 'DIRECT': return 'slutkund'
+
+        default: throw 'unknown senderType ' + senderType
+      }
+    },
   },
 
   props: {

--- a/frontend/src/views/Main.vue
+++ b/frontend/src/views/Main.vue
@@ -53,10 +53,28 @@
         <textarea style="height: 300px;" v-model.trim="assignment.description"></textarea>
       </label>
 
-      <label>
-        Kontaktuppgifter till ansvarig person (namn, telefonnummer m.m.):
-        <textarea style="height: 150px;" v-model.trim="assignment.contact"></textarea>
-      </label>
+      <div class="columns">
+        <div class="column">
+          <label>
+            Kontaktuppgifter till ansvarig person (namn, telefonnummer m.m.):
+            <textarea style="height: 150px;" v-model.trim="assignment.contact"></textarea>
+          </label>
+        </div>
+
+        <div class="column">
+          <label>Typ av kontakt:</label>
+
+          <label class="radio">
+            <input type="radio" value="BROKER" v-model="assignment.senderType" />
+            Konsultmäklare eller motsvarande mellanhand
+          </label>
+
+          <label class="radio">
+            <input type="radio" value="DIRECT" v-model="assignment.senderType" />
+            Direktkontakt med slutkund
+          </label>
+        </div>
+      </div>
 
       <input type="submit" value="Fortsätt" :disabled="somethingIsMissing" />
     </form>
@@ -77,6 +95,7 @@ export default {
   data: () => ({
     state: 'CRAFT',
     assignment: {
+      senderType: null,
       title: '',
       description: '',
       customerName: '',


### PR DESCRIPTION
Denna ändring gör att man som publicist av ett uppdrag behöver välja om man representerar slutkunden eller en typ av förmedlare, exempelvis en konsultmäklare. Valet styr vilken Slack-kanal uppdraget publiceras i.

![image](https://user-images.githubusercontent.com/889617/154797292-3b2beb8d-ca11-48af-9e20-8ed1fb7cb311.png)

Jag passade även på att ersätta alla tabbar med mellanslag i backendkoden.