### PR TITLE
CSS-kod för radioknapparna även i skrivbordsvyn

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -101,6 +101,11 @@ label > input[type='radio'] {
 
 label.radio {
   display: block;
+  margin-bottom: 15px;
+}
+
+label.radio input {
+  margin-bottom: 10px;
 }
 
 label:not(.radio) + label.radio {
@@ -135,14 +140,6 @@ textarea:focus-visible {
   .columns > .column {
     flex-shrink: 0;
     padding: 0;
-  }
-
-  label.radio {
-    margin-bottom: 15px;
-  }
-
-  label.radio input {
-    margin-bottom: 10px;
   }
 }
 </style>


### PR DESCRIPTION
Efter att texten vid en av radioknapparna blev längre började den skrivas ut konstigt i skrivbordsvyn. I https://github.com/frilansaresverige/uppdrag-integration/pull/8 åtgärdades det för mobilvyn, men här åtgärdas det också för skrivbordsvyn.

Före:
![image](https://github.com/frilansaresverige/uppdrag-integration/assets/889617/44d84e40-db7e-453f-a243-efacb059e0dc)

Efter:
![image](https://github.com/frilansaresverige/uppdrag-integration/assets/889617/fe7f2656-a242-40e3-8083-ea8322a70a7b)
