### PR TITLE
Införde begränsning i antal tillåtna tecken i uppdragsbeskrivningar

### DIFF
--- a/frontend/src/views/Main.vue
+++ b/frontend/src/views/Main.vue
@@ -50,7 +50,8 @@
 
       <label>
         Beskrivning av uppdraget och uppdragsgivarens behov:
-        <textarea v-model.trim="assignment.description" style="height: 300px"></textarea>
+        <textarea v-model.trim="assignment.description" style="height: 300px" maxlength="500"></textarea>
+        <div v-if="assignment.description.length > 450" :class="{ lengthWarning: true, lengthError: assignment.description.length > 495 }">Du har använt {{ assignment.description.length }} av 500 tecken.</div>
       </label>
 
       <div class="columns">
@@ -153,3 +154,15 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.lengthWarning {
+  margin: -20px 0 20px;
+  color: #f28c28;
+  font-weight: 700;
+}
+
+.lengthError {
+  color: red;
+}
+</style>


### PR DESCRIPTION
De här ändringarna inför en begränsning av hur många tecken man kan skriva i fältet för uppdragsbeskrivningar. Begränsningen är satt efter att Slack verkar bryta upp meddelanden efter ungefär 900-1000 tecken. Se ett exempel [här](https://frilansare-sverige.slack.com/archives/C0319MQLLQ3/p1725006656634239) och hur det fortsätter [här](https://frilansare-sverige.slack.com/archives/C0319MQLLQ3/p1725006656655839).

När man har skrivit fler än 450 men färre än 495 tecken:
![Screenshot_20240830_112921](https://github.com/user-attachments/assets/d5a5ce8d-610e-4938-99f5-ad481d367266)

När man har skrivit 495 eller fler tecken:
![Screenshot_20240830_112330-1](https://github.com/user-attachments/assets/57129f9c-7600-41bb-8811-76d454d5d3a8)

Begränsningen har en begränsning i form av att den endast sker på klientsidan. Jag tycker att det kan vara gott nog så länge. Det finns inte heller någon teckenbegränsning på de andra fälten, eller när man kompletterar en publikation, men det tycker jag inte behövs i dagsläget.