### PR TITLE
Låt uppdragsbeskrivningar ligga som svar

### DIFF
--- a/backend/config.js.example
+++ b/backend/config.js.example
@@ -32,16 +32,17 @@ module.exports = {
 
       Hälsningar från Frilansare Sverige
     `,
-    slackAssignment: `
+    slackAssignmentInitial: `
     *[[TITLE]]*
 
     *Uppdragsgivare:* [[CUSTOMER_NAME]]
     
-    *Beskrivning:*
-    [[DESCRIPTION]]
-    
     *Kontaktuppgifter:*
     [[CONTACT]]
+    `,
+    slackAssignmentThread: `
+    *Beskrivning:*
+    [[DESCRIPTION]]
     `,
     slackAssignmentComment: `
     *Komplettering*:

--- a/backend/src/slack.js
+++ b/backend/src/slack.js
@@ -15,33 +15,49 @@ exports.sync = async () => {
 exports.propagateAssignment = async assignmentId => {
   const assignment = await model.getAssignment(assignmentId)
 
-  const text = common.fillTemplate(config.templates.slackAssignment, assignment)
-
-  const params = new URLSearchParams()
-
-  params.append('token', config.slack.token)
-  params.append('channel', assignment.slackChannel)
-  params.append('text', text)
-
-  let ok, ts
-
-  try {
-    const response = await axios.post('https://slack.com/api/chat.postMessage', params)
-
-    ok = response.data.ok
-
-    if (ok) {
-      ts = response.data.ts
-    } else {
-      throw response.data
-    }
-  } catch (error) {
-    console.error('Failed to post assignment ' + assignmentId + ' to Slack:')
-    console.error(error)
+  const text = {
+    'INITIAL': common.fillTemplate(config.templates.slackAssignmentInitial, assignment),
+    'THREAD': common.fillTemplate(config.templates.slackAssignmentThread, assignment),
   }
 
-  if (ok) {
-    await model.setAssignmentSlackId(assignment.id, ts)
+  let threadId = null
+
+  for (const job of ['INITIAL', 'THREAD']) {
+    if (job === 'THREAD' && threadId === null) {
+      continue
+    }
+
+    const params = new URLSearchParams()
+
+    params.append('token', config.slack.token)
+    params.append('channel', assignment.slackChannel)
+    params.append('text', text[job])
+
+    if (job === 'THREAD') {
+      params.append('thread_ts', threadId)
+    }
+
+    let ok, ts
+
+    try {
+      const response = await axios.post('https://slack.com/api/chat.postMessage', params)
+
+      ok = response.data.ok
+
+      if (ok) {
+        ts = response.data.ts
+      } else {
+        throw response.data
+      }
+    } catch (error) {
+      console.error('Failed to post assignment ' + assignmentId + ' for ' + job + ' to Slack:')
+      console.error(error)
+    }
+
+    if (ok && job === 'INITIAL') {
+      await model.setAssignmentSlackId(assignment.id, ts)
+      threadId = ts
+    }
   }
 }
 


### PR DESCRIPTION
Dessa ändringar gör så att uppdragsbeskrivningen läggs som ett svar i stället för att vara en del av ursprungsinlägget. Fördelen är att uppdragsbeskrivningen, som ofta är det längsta textstycket, tar upp mindre plats och gör det enklare för frilansarna att få en överblick av inkommande uppdrag.