### PR TITLE
Lägg till fler fält för mäklare att fylla i

### DIFF
--- a/backend/config.js.example
+++ b/backend/config.js.example
@@ -52,7 +52,7 @@ module.exports = {
     *Beskrivning:*
     [[DESCRIPTION]]
 
-    *Länk till Allabolag:* [[CUSTOMER_COMPANY_URL]]
+    *Om uppdragsgivaren:* [[CUSTOMER_COMPANY_URL]]
     `,
     slackAssignmentComment: `
     *Komplettering*:

--- a/backend/config.js.example
+++ b/backend/config.js.example
@@ -35,7 +35,15 @@ module.exports = {
     slackAssignmentInitial: `
     *[[TITLE]]*
 
+    *Plats:* [[LOCATION]]
+
     *Uppdragsgivare:* [[CUSTOMER_NAME]]
+
+    *Avsändare:* [[SENDER_EMAIL]]
+
+    *Mellanhandsavgift:* [[CUSTOMER_FEE]] 
+
+    *Minimum arvode:* [[HOURLY_RATE]] kr/h
     
     *Kontaktuppgifter:*
     [[CONTACT]]
@@ -43,6 +51,8 @@ module.exports = {
     slackAssignmentThread: `
     *Beskrivning:*
     [[DESCRIPTION]]
+
+    *Länk till Allabolag:* [[CUSTOMER_COMPANY_URL]]
     `,
     slackAssignmentComment: `
     *Komplettering*:

--- a/backend/src/common.js
+++ b/backend/src/common.js
@@ -19,6 +19,12 @@ exports.randomString = (length = 16) => {
 
 exports.getTimestamp = () => Math.round(Date.now() / 1000)
 
+exports.parseOrganizationNumber = (organizationNumber) => {
+  const stripped = organizationNumber.replace(/[^A-Za-z0-9]/g, '')
+
+  return stripped
+}
+
 // https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
 exports.validateEmail = emailAddress => {
   if (typeof emailAddress !== 'string') {
@@ -50,22 +56,22 @@ exports.fillTemplate = (template, source) => {
   body = body.replace(/\[\[LOCATION\]\]/g, source.location)
 
 
-  if(source.customerCompanyURL) {
-    body = body.replace(/\[\[CUSTOMER_COMPANY_URL\]\]/g, source.customerCompanyURL)
+  if (source.customerOrganizationNumber) {
+    body = body.replace(/\[\[CUSTOMER_COMPANY_URL\]\]/g, this.createCompanyURL(source.customerOrganizationNumber))
   } else {
     body = body.replace(/^.*\[\[CUSTOMER_COMPANY_URL\]\].*\n?/gm, '')
   }
 
-  if(source.clientHourlyRate){
+  if (source.clientHourlyRate) {
     body = body.replace(/\[\[HOURLY_RATE\]\]/g, source.clientHourlyRate)
   } else {
     body = body.replace(/^.*\[\[HOURLY_RATE\]\].*\r?\n.*\r?\n?/gm, '')
   }
 
-  if(source.customerFee){
+  if (source.customerFee) {
     body = body.replace(/\[\[CUSTOMER_FEE\]\]/g, source.customerFee)
   } else {
-    if(source.senderType === 'DIRECT'){
+    if(source.senderType === 'DIRECT') {
       body = body.replace(/^.*\[\[CUSTOMER_FEE\]\].*\r?\n.*\r?\n?/gm, '')
     }
     body = body.replace(/\[\[CUSTOMER_FEE\]\]/g, 'Vill ej uppge')
@@ -108,4 +114,11 @@ exports.sendEmail = async (to, subject, text) => {
   }
 
   return transporter.sendMail(options)
+}
+
+exports.createCompanyURL = (organizationNumber) => {
+  const parsedOrganizationNumber = this.parseOrganizationNumber(organizationNumber)
+  const url = `https://www.allabolag.se/bransch-s%C3%B6k?q=${parsedOrganizationNumber}`
+
+  return url
 }

--- a/backend/src/common.js
+++ b/backend/src/common.js
@@ -46,6 +46,30 @@ exports.fillTemplate = (template, source) => {
   body = body.replace(/\[\[CONTACT\]\]/g, source.contact)
   body = body.replace(/\[\[URL\]\]/g, config.hostname + '/assignments/' + source.id)
   body = body.replace(/\[\[COMMENT\]\]/g, source.comment)
+  body = body.replace(/\[\[SENDER_EMAIL\]\]/g, source.emailAddress)
+  body = body.replace(/\[\[LOCATION\]\]/g, source.location)
+
+
+  if(source.customerCompanyURL) {
+    body = body.replace(/\[\[CUSTOMER_COMPANY_URL\]\]/g, source.customerCompanyURL)
+  } else {
+    body = body.replace(/^.*\[\[CUSTOMER_COMPANY_URL\]\].*\n?/gm, '')
+  }
+
+  if(source.clientHourlyRate){
+    body = body.replace(/\[\[HOURLY_RATE\]\]/g, source.clientHourlyRate)
+  } else {
+    body = body.replace(/^.*\[\[HOURLY_RATE\]\].*\r?\n.*\r?\n?/gm, '')
+  }
+
+  if(source.customerFee){
+    body = body.replace(/\[\[CUSTOMER_FEE\]\]/g, source.customerFee)
+  } else {
+    if(source.senderType === 'DIRECT'){
+      body = body.replace(/^.*\[\[CUSTOMER_FEE\]\].*\r?\n.*\r?\n?/gm, '')
+    }
+    body = body.replace(/\[\[CUSTOMER_FEE\]\]/g, 'Vill ej uppge')
+  }
 
   return body
 }

--- a/backend/src/model.js
+++ b/backend/src/model.js
@@ -10,7 +10,7 @@ exports.setPool = pool => {
   this.pool = pool
 }
 
-exports.saveAssignment = async (senderType, emailAddress, customerName, title, description, contact) => {
+exports.saveAssignment = async (senderType, emailAddress, customerName, title, description, contact, customerFee, customerCompanyURL, clientHourlyRate, location) => {
   const id = common.randomString()
   const created = common.getTimestamp()
   const slackId = null
@@ -28,9 +28,13 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
       contact,
       created,
       slackChannel,
-      slackId
+      slackId,
+      customerCompanyURL,
+      customerFee,
+      clientHourlyRate,
+      location
     )
-    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       id,
       senderType,
@@ -42,6 +46,10 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
       created,
       slackChannel,
       slackId,
+      customerCompanyURL,
+      customerFee,
+      clientHourlyRate,
+      location
     ],
   )
 
@@ -63,7 +71,11 @@ exports.getAssignment = async assignmentId => {
       contact,
       created,
       slackChannel,
-      slackId
+      slackId,
+      customerCompanyURL,
+      customerFee,
+      clientHourlyRate,
+      location
     FROM assignment
     WHERE id = ?
     `,

--- a/backend/src/model.js
+++ b/backend/src/model.js
@@ -10,7 +10,7 @@ exports.setPool = pool => {
   this.pool = pool
 }
 
-exports.saveAssignment = async (senderType, emailAddress, customerName, title, description, contact, customerFee, customerCompanyURL, clientHourlyRate, location) => {
+exports.saveAssignment = async (senderType, emailAddress, customerName, title, description, contact, customerFee, customerOrganizationNumber, clientHourlyRate, location) => {
   const id = common.randomString()
   const created = common.getTimestamp()
   const slackId = null
@@ -29,7 +29,7 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
       created,
       slackChannel,
       slackId,
-      customerCompanyURL,
+      customerOrganizationNumber,
       customerFee,
       clientHourlyRate,
       location
@@ -46,7 +46,7 @@ exports.saveAssignment = async (senderType, emailAddress, customerName, title, d
       created,
       slackChannel,
       slackId,
-      customerCompanyURL,
+      customerOrganizationNumber,
       customerFee,
       clientHourlyRate,
       location
@@ -72,7 +72,7 @@ exports.getAssignment = async assignmentId => {
       created,
       slackChannel,
       slackId,
-      customerCompanyURL,
+      customerOrganizationNumber,
       customerFee,
       clientHourlyRate,
       location

--- a/backend/src/rest/assignments.js
+++ b/backend/src/rest/assignments.js
@@ -15,11 +15,11 @@ router.post('/', async (req, res) => {
   let description = req.body.description
   let contact = req.body.contact
   let customerFee = req.body.customerFee
-  let customerCompanyURL = req.body.customerCompanyURL
+  let customerOrganizationNumber = req.body.customerOrganizationNumber
   let clientHourlyRate = req.body.clientHourlyRate
   let location = req.body.location
 
-  if (typeof customerName !== 'string' || typeof title !== 'string' || typeof description !== 'string' || typeof contact !== 'string' || typeof contact !== 'string') {
+  if (typeof customerName !== 'string' || typeof title !== 'string' || typeof description !== 'string' || typeof contact !== 'string' || (customerFee !== null && typeof customerFee !== 'string') || typeof customerOrganizationNumber !== 'string' || typeof location !== 'string' || (clientHourlyRate !== null && typeof clientHourlyRate !== 'number'))  {
     res.status(400).end()
     return
   }
@@ -31,7 +31,7 @@ router.post('/', async (req, res) => {
     return
   }
 
-  if (emailAddress.length > 50 || title.length > 50 || title.length > 50 || !['BROKER', 'DIRECT'].includes(senderType)) {
+  if (emailAddress.length > 50 || title.length > 50 || title.length > 50 || customerOrganizationNumber.length > 15 || !['BROKER', 'DIRECT'].includes(senderType)) {
     res.status(400).end()
     return
   }
@@ -44,14 +44,14 @@ router.post('/', async (req, res) => {
     description,
     contact,
     customerFee,
-    customerCompanyURL,
+    customerOrganizationNumber,
     clientHourlyRate,
     location,
   )
 
   res.status(201).end()
 
-  // common.sendConfirmationEmail(assignmentId)
+  common.sendConfirmationEmail(assignmentId)
 })
 
 router.get('/:assignmentId', async (req, res) => {

--- a/backend/src/rest/assignments.js
+++ b/backend/src/rest/assignments.js
@@ -14,8 +14,12 @@ router.post('/', async (req, res) => {
   let title = req.body.title
   let description = req.body.description
   let contact = req.body.contact
+  let customerFee = req.body.customerFee
+  let customerCompanyURL = req.body.customerCompanyURL
+  let clientHourlyRate = req.body.clientHourlyRate
+  let location = req.body.location
 
-  if (typeof customerName !== 'string' || typeof title !== 'string' || typeof description !== 'string' || typeof contact !== 'string') {
+  if (typeof customerName !== 'string' || typeof title !== 'string' || typeof description !== 'string' || typeof contact !== 'string' || typeof contact !== 'string') {
     res.status(400).end()
     return
   }
@@ -39,11 +43,15 @@ router.post('/', async (req, res) => {
     title,
     description,
     contact,
+    customerFee,
+    customerCompanyURL,
+    clientHourlyRate,
+    location,
   )
 
   res.status(201).end()
 
-  common.sendConfirmationEmail(assignmentId)
+  // common.sendConfirmationEmail(assignmentId)
 })
 
 router.get('/:assignmentId', async (req, res) => {

--- a/backend/structure.sql
+++ b/backend/structure.sql
@@ -33,3 +33,8 @@ ALTER TABLE `assignmentComment`
 ALTER TABLE `assignmentComment`
   ADD CONSTRAINT `assignmentComment_ibfk_1` FOREIGN KEY (`assignment`) REFERENCES `assignment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
+ALTER TABLE `assignment`
+  ADD COLUMN `customerCompanyURL` TEXT COLLATE utf8mb4_unicode_ci AFTER `customerName`,
+  ADD COLUMN `customerFee` VARCHAR(50) DEFAULT NULL AFTER `customerCompanyURL`,
+  ADD COLUMN `clientHourlyRate` VARCHAR(20) DEFAULT NULL AFTER `customerFee`;
+  ADD COLUMN `location` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/backend/structure.sql
+++ b/backend/structure.sql
@@ -34,7 +34,7 @@ ALTER TABLE `assignmentComment`
   ADD CONSTRAINT `assignmentComment_ibfk_1` FOREIGN KEY (`assignment`) REFERENCES `assignment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 ALTER TABLE `assignment`
-  ADD COLUMN `customerCompanyURL` TEXT COLLATE utf8mb4_unicode_ci AFTER `customerName`,
-  ADD COLUMN `customerFee` VARCHAR(50) DEFAULT NULL AFTER `customerCompanyURL`,
-  ADD COLUMN `clientHourlyRate` VARCHAR(20) DEFAULT NULL AFTER `customerFee`;
+  ADD COLUMN `customerOrganizationNumber` varchar(15) COLLATE utf8mb4_unicode_ci AFTER `customerName`,
+  ADD COLUMN `customerFee` varchar(50) DEFAULT NULL AFTER `customerOrganizationNumber`,
+  ADD COLUMN `clientHourlyRate` varchar(20) DEFAULT NULL AFTER `customerFee`;
   ADD COLUMN `location` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -94,6 +94,17 @@ input[type='submit']:active {
   background-color: #cccccc;
 }
 
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: none;
+}
+
 label > input[type='radio'] {
   display: inline;
   width: auto;

--- a/frontend/src/views/Main.vue
+++ b/frontend/src/views/Main.vue
@@ -12,14 +12,14 @@
 
     <assignment :assignment="assignment" />
 
-    <p>Vill du ändra något? <a @click="state = 'CRAFT'">Gå tillbaka till formuläret »</a></p>
+    <p>Vill du ändra något? <a @click="goBack">Gå tillbaka till formuläret »</a></p>
 
     <p>I annat fall, ange din e-postadress för att publicera uppdraget. Du kommer få en kvittens skickad till den.</p>
 
     <form @submit.prevent="publishAssignment">
       <label>
         Din e-postadress:
-        <input v-model.trim="emailAddress" type="text" :disabled="isPublishing" :maxlength="50" />
+        <input v-model.trim="emailAddress" type="email" :disabled="isPublishing" :maxlength="50" />
       </label>
 
       <input type="submit" value="Publicera" :disabled="!emailAddress || isPublishing" />
@@ -27,7 +27,7 @@
   </template>
 
   <template v-if="state === 'CRAFT'">
-    <p>Använd nedanstående formulär för att publicera ett konsultuppdrag till svenska frilansare och egenkonsulter inom it-branschen.</p>
+    <p>Använd nedanstående formulär för att publicera ett konsultuppdrag till svenska frilansare och egenkonsulter.</p>
 
     <p>Vill du veta mer om vad det här är innan du går vidare? <router-link to="/information">Läs om den här tjänsten »</router-link></p>
 
@@ -39,12 +39,52 @@
             <input v-model.trim="assignment.title" type="text" :maxlength="50" />
           </label>
         </div>
+      </div>
 
+      <div class="column">
+        <label>
+          Plats:
+          <input v-model.trim="assignment.location" type="text" :maxlength="50" placeholder="t.ex. Remote / Göteborg / Hybrid Stockholm (2dgr/v)" />
+        </label>
+      </div>
+      <div class="columns">
         <div class="column">
           <label>
             Uppdragsgivarens namn:
             <input v-model.trim="assignment.customerName" type="text" :maxlength="50" placeholder="t.ex. företagets namn" />
           </label>
+        </div>
+
+        <div v-if="assignment.senderType === 'BROKER'" class="column">
+          <label>
+            Vårt bolags sida på allabolag.se:
+            <input v-model.trim="assignment.customerCompanyURL" type="url" :maxlength="300" placeholder="https://allabolag.se/..." />
+          </label>
+        </div>
+      </div>
+
+      <div class="columns">
+        <div class="column">
+          <label>
+            Minimumarvode till frilansaren:
+            <div class="with-unit">
+              <input v-model.number="assignment.clientHourlyRate" type="number" placeholder="t.ex 1000" />
+              <span class="unit">kr/h</span>
+            </div>
+          </label>
+        </div>
+      </div>
+
+      <div v-if="assignment.senderType === 'BROKER'" class="columns">
+        <div class="column">
+          <div>
+            <label>Vår avgift som mellanhand är</label>
+            <input v-model.trim="assignment.customerFee" type="text" placeholder="t.ex. 10 % eller 50 kr/h" :disabled="assignment.isNonTransparentFee" :required="!assignment.isNonTransparentFee && assignment.senderType === 'BROKER'" />
+          </div>
+          <div class="checkbox-wrapper">
+            <input v-model="assignment.isNonTransparentFee" type="checkbox" class="transparent-checkbox" />
+            <label class="checkbox-label">Vi är inte transparenta med vår avgift</label>
+          </div>
         </div>
       </div>
 
@@ -99,6 +139,12 @@ export default {
       title: '',
       description: '',
       customerName: '',
+      customerCompanyURL: null,
+      customerFee: null,
+      isNonTransparentFee: false,
+      clientHourlyRate: null,
+      contact: '',
+      location: '',
     },
     emailAddress: '',
     previewMode: false,
@@ -107,7 +153,10 @@ export default {
 
   computed: {
     somethingIsMissing: function () {
-      return !!Object.keys(this.assignment).find(x => !this.assignment[x])
+      const requiredFieldsFilled = !!this.assignment.title && !!this.assignment.description && !!this.assignment.customerName && !!this.assignment.senderType && !!this.assignment.contact
+      const brokerFeeFilled = this.assignment.senderType !== 'BROKER' || this.assignment.isNonTransparentFee || !!this.assignment.customerFee
+
+      return !requiredFieldsFilled || !brokerFeeFilled
     },
   },
 
@@ -115,11 +164,20 @@ export default {
     state: function () {
       window.scrollTo(0, 0)
     },
+    'assignment.isNonTransparentFee': function (newVal) {
+      if (newVal) {
+        this.assignment.customerFee = null
+      }
+    },
   },
 
   methods: {
     goToPreview() {
       this.state = 'PREVIEW'
+    },
+
+    goBack() {
+      this.state = 'CRAFT'
     },
 
     async publishAssignment() {
@@ -133,23 +191,75 @@ export default {
 
         this.state = 'PUBLISHED'
       } catch (error) {
-        if (error.response) {
-          if (error.response.status === 400) {
-            switch (error.response.data) {
-              case 'INVALID_EMAIL_ADDRESS':
-                alert('E-postadressen är ogiltig.')
-                return
-            }
-          }
-
-          alert('Ett okänt fel inträffade när uppdraget skulle publiceras.')
-        } else {
-          alert('Ett oväntat fel inträffade när uppdraget skulle publiceras.')
-        }
+        this.handleApiError(error)
       } finally {
         this.isPublishing = false
+      }
+    },
+
+    handleApiError(error) {
+      if (error.response) {
+        if (error.response.status === 400) {
+          switch (error.response.data) {
+            case 'INVALID_EMAIL_ADDRESS':
+              alert('E-postadressen är ogiltig.')
+              return
+          }
+        }
+
+        alert('Ett okänt fel inträffade när uppdraget skulle publiceras.')
+      } else {
+        alert('Ett oväntat fel inträffade när uppdraget skulle publiceras.')
       }
     },
   },
 }
 </script>
+
+<style scoped>
+.with-unit {
+  position: relative;
+}
+
+.with-unit input {
+  width: 100%;
+  padding-right: 50px;
+  box-sizing: border-box;
+}
+
+.with-unit .unit {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+  position: relative;
+}
+
+.transparent-checkbox {
+  display: inline-block !important;
+  width: auto !important;
+  margin: 0 5px 0 0 !important;
+  vertical-align: middle !important;
+}
+
+.checkbox-label {
+  display: inline !important;
+  margin: 0 !important;
+}
+
+.checkbox-wrapper + div label {
+  margin-top: 0 !important;
+}
+
+input[type='checkbox'].transparent-checkbox {
+  position: relative;
+  top: -1px;
+}
+</style>

--- a/frontend/src/views/Main.vue
+++ b/frontend/src/views/Main.vue
@@ -57,8 +57,8 @@
 
         <div v-if="assignment.senderType === 'BROKER'" class="column">
           <label>
-            Vårt bolags sida på allabolag.se:
-            <input v-model.trim="assignment.customerCompanyURL" type="url" :maxlength="300" placeholder="https://allabolag.se/..." />
+            Uppdragsgivarens organisationsnummer:
+            <input v-model.trim="assignment.customerOrganizationNumber" type="text" :maxlength="15" placeholder="123456-7890" />
           </label>
         </div>
       </div>
@@ -139,7 +139,7 @@ export default {
       title: '',
       description: '',
       customerName: '',
-      customerCompanyURL: null,
+      customerOrganizationNumber: '',
       customerFee: null,
       isNonTransparentFee: false,
       clientHourlyRate: null,
@@ -157,6 +157,10 @@ export default {
       const brokerFeeFilled = this.assignment.senderType !== 'BROKER' || this.assignment.isNonTransparentFee || !!this.assignment.customerFee
 
       return !requiredFieldsFilled || !brokerFeeFilled
+    },
+    normalizedHourlyRate() {
+      const rate = this.assignment.clientHourlyRate
+      return rate === '' || isNaN(rate) ? null : Number(rate)
     },
   },
 
@@ -186,6 +190,7 @@ export default {
       try {
         await axios.post('/api/assignments', {
           ...this.assignment,
+          clientHourlyRate: this.normalizedHourlyRate,
           emailAddress: this.emailAddress,
         })
 


### PR DESCRIPTION
### Ändringar för frontend:
- Ändrade så att **Uppdragsgivarens namn** hamnar som en kolumn **under uppdragets titel**
- Har lagt till en input för alla senderTypes (BROKER & DIRECT): **Minimumarvode till frilansaren:**
- Har lagt till en input för arvode till frilansaren.
- Har lagt till en input för arvode till mäklaren.
- Har lagt till en checkbox om man inte vill ange mäklararvode.

Minor refactors:
- Funktion för felhantering från API.
- goBack som en funktion likt goToPreview

### Ändringar för backend:
- Uppdaterade SQL med en alter query för att spara nya kolumner
  - customerCompanyURL
  - customerFee
  - clientHourlyRate
- Valde VARCHAR för customerFee, clientHourlyRate för enkelhetens skull.
 
- Uppdaterade common.fillTemplate funktionen att parsea lite mer text och lägga till korrekt data, ta bort raden eller lägga till en default text.
- Länk till alla bolag hamnar i tråden, Uppdragsgivare, Avsändare, Avgift till mellanhand, Minimumarvode till frilansaren hamnar i kanalen.
