### PR TITLE
API-ändpunkt för antalet medlemmar

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -35,8 +35,12 @@ app.use('/api/assignments', require('./rest/assignments'))
 
 app.use('/api/health', require('./rest/health'))
 
+app.use('/api/member-count', require('./rest/member-count'))
+
 model.setPool(pool)
 
 slack.sync()
+
+slack.startMemberCountRefresh()
 
 httpServer.listen(config.listen.port, config.listen.ip)

--- a/backend/src/rest/member-count.js
+++ b/backend/src/rest/member-count.js
@@ -13,7 +13,7 @@ router.get('/', (req, res) => {
     return res.status(503).end()
   }
 
-  res.json(cached)
+  res.type('text/plain').send(String(cached))
 })
 
 module.exports = router

--- a/backend/src/rest/member-count.js
+++ b/backend/src/rest/member-count.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const express = require('express')
+
+const slack = require('../slack')
+
+const router = express.Router()
+
+router.get('/', (req, res) => {
+  const cached = slack.getMemberCount()
+
+  if (cached === null) {
+    return res.status(503).end()
+  }
+
+  res.json(cached)
+})
+
+module.exports = router

--- a/backend/src/slack.js
+++ b/backend/src/slack.js
@@ -142,8 +142,6 @@ exports.getUsers = async () => {
 
 exports.refreshMemberCount = async () => {
   try {
-    console.log('Refreshing member count cache...')
-
     const response = await axios.get('https://slack.com/api/conversations.info', {
       headers: {
         Authorization: `Bearer ${config.slack.token}`,
@@ -160,7 +158,6 @@ exports.refreshMemberCount = async () => {
     }
 
     memberCountCache = response.data.channel.num_members
-    console.log('Member count cache refreshed:', memberCountCache)
   } catch (error) {
     console.error('Error refreshing member count cache:', error.message)
   }


### PR DESCRIPTION
De här ändringarna lägger till `/api/member-count` så att man kan få ut antalet medlemmar i Slack-gemenskapen.

Exempel:
```
$ curl http://localhost:8989/api/member-count
2964
```